### PR TITLE
Add report-loggers option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,3 +17,9 @@ Usage
 
     $ pylint --load-plugins sentry_stack_checker <module> -E -d all -e R9501
     $ pylint --load-plugins sentry_stack_checker <module> -E -d all -e R9502
+
+The option ``report-loggers`` can be provided to restrict the logging methods that are checked:
+
+::
+
+    $ pylint --load-plugins sentry_stack_checker <module> --report-loggers=warning,error

--- a/sentry_stack_checker.py
+++ b/sentry_stack_checker.py
@@ -61,9 +61,6 @@ def includes_extra_stack(node):
 
 
 def includes_exc_info(node):
-    if node.func.attrname == 'exception':
-        return True
-
     try:
         exc_info = utils.get_argument_from_call(node, keyword='exc_info')
     except utils.NoSuchArgumentError:

--- a/sentry_stack_checker.py
+++ b/sentry_stack_checker.py
@@ -120,6 +120,13 @@ class SentryStackChecker(BaseChecker):
         ),
     )
 
+    def set_option(self, optname, *args, **kwargs):
+        super(SentryStackChecker, self).set_option(optname, *args, **kwargs)
+
+        # Update complete logging methods to report
+        if optname == 'report-loggers':
+            self.logging_methods_to_report = complete_logging_methods(self.config.report_loggers)
+
     @utils.check_messages(ADD_EXC_INFO, CHANGE_TO_EXC_INFO)
     def visit_call(self, node):
         """Called for every function call in the source code."""
@@ -128,8 +135,7 @@ class SentryStackChecker(BaseChecker):
             # we are looking for method calls
             return
 
-        logging_methods_to_report = complete_logging_methods(self.config.report_loggers)
-        if node.func.attrname not in logging_methods_to_report:
+        if node.func.attrname not in self.logging_methods_to_report:
             return
 
         if not is_logger_class(node):

--- a/test_sentry_stack_checker.py
+++ b/test_sentry_stack_checker.py
@@ -127,6 +127,38 @@ except:
     assert errors == []
 
 
+def set_option_to_checker(linter, checker_name, option, value):
+    for checker in linter.get_checkers():
+        if checker.name == checker_name:
+            checker.set_option(option, value)
+
+
+def test_report_loggers_option(make_source, linter):
+    set_option_to_checker(linter, 'sentry-stack-checker', 'report-loggers', ['warn', 'error'])
+    source = make_source("""
+try:
+    pass
+except:
+    logger.info('foo')
+""")
+    linter.check([str(source)])
+    errors = [message.symbol for message in linter.reporter.messages]
+    assert errors == []
+
+
+def test_report_warn_if_warning_provided_to_report_loggers(make_source, linter):
+    set_option_to_checker(linter, 'sentry-stack-checker', 'report-loggers', ['warning'])
+    source = make_source("""
+try:
+    pass
+except:
+    logger.warn('foo')
+""")
+    linter.check([str(source)])
+    errors = [message.symbol for message in linter.reporter.messages]
+    assert errors == [SentryStackChecker.ADD_EXC_INFO]
+
+
 def find_children(node):
     children = [node]
     for child in children:


### PR DESCRIPTION
where whitelist of logging methods can be provided.

Fixes https://github.com/davidszotten/sentry-stack-checker/issues/4.