### PR TITLE
Improve test coverage

### DIFF
--- a/test_sentry_stack_checker.py
+++ b/test_sentry_stack_checker.py
@@ -146,6 +146,19 @@ except:
     assert errors == []
 
 
+def test_report_loggers_option_debug(make_source, linter):
+    set_option_to_checker(linter, 'sentry-stack-checker', 'report-loggers', ['debug'])
+    source = make_source("""
+try:
+    pass
+except:
+    logger.info('foo')
+""")
+    linter.check([str(source)])
+    errors = [message.symbol for message in linter.reporter.messages]
+    assert errors == []
+
+
 def test_report_warn_if_warning_provided_to_report_loggers(make_source, linter):
     set_option_to_checker(linter, 'sentry-stack-checker', 'report-loggers', ['warning'])
     source = make_source("""


### PR DESCRIPTION
I used Coverage.py: 'coverage --branch' to get coverage.

From:

Name                      Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------------------------
sentry_stack_checker.py      72      0     35      2    98%   21->24, 124->exit

to:

Name                      Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------------------------
sentry_stack_checker.py      72      0     35      1    99%   124->exit

As far as I can see it is not possible to set unknown option and reach
100% branch coverage.